### PR TITLE
feat(cli): implement --version and -v global flags

### DIFF
--- a/src/prism/entrypoints/cli/branding.py
+++ b/src/prism/entrypoints/cli/branding.py
@@ -1,8 +1,10 @@
 import sys
 from rich.console import Console
 from rich.text import Text
+from prism import __version__
 
 #_ Use stderr for branding to avoid polluting stdout (important for MCP/pipes)
+
 console = Console(stderr=True)
 
 # ... (LOGO and VERSION_TEXT constants remain the same)
@@ -15,9 +17,10 @@ LOGO = r"""
 [blue] ╚═════╝ ╚═╝  ╚═╝╚═════╝ ╚═╝╚══════╝╚═╝     ╚═╝  ╚═╝╚═╝╚══════╝╚═╝     ╚═╝[/blue]
 """                                                                     
 
-VERSION_TEXT = "VERSION 1.0.3 | ORBISFACTORY"
+VERSION_TEXT = f"VERSION {__version__} | ORBISFACTORY"
 
 def get_logo_and_version() -> Text:
+
     """Returns the ASCII art logo and version information combined as a Rich Text object."""
     logo_lines = LOGO.strip().split('\n')
     cleaned_logo_lines = [Text.from_markup(line).plain for line in logo_lines]

--- a/src/prism/entrypoints/cli/main.py
+++ b/src/prism/entrypoints/cli/main.py
@@ -6,7 +6,7 @@ from typing_extensions import Annotated
 
 import typer
 
-from ... import i18n
+from ... import i18n, __version__
 from ...infrastructure import config_impl
 
 from . import branding
@@ -33,9 +33,16 @@ try:
 except ImportError:
     pass
 
+def version_callback(value: bool):
+    """Callback for the --version flag."""
+    if value:
+        #_ Logo is already printed in main(), so we just exit
+        raise typer.Exit()
+
 @app.callback()
 def main_callback(
     ctx: typer.Context,
+    version: Annotated[bool | None, typer.Option("--version", "-v", callback=version_callback, is_eager=True, help=i18n.t("cli.help.version"))] = None,
     workspace: Annotated[Path | None, typer.Option("--workspace", "-w", help="Path to the Hytale project workspace")] = None,
 ):  
     """Sets the project root context."""

--- a/src/prism/locales/en.json
+++ b/src/prism/locales/en.json
@@ -14,6 +14,7 @@
   "cli.help.arguments_panel": "Arguments",
   "cli.help.commands_panel": "Commands",
   "cli.help.options_panel": "Options",
+  "cli.help.version": "Show the version and exit.",
   "cli.help.decompile_desc": "Decompiles the JAR and leaves only com.hypixel.hytale. Default: release; --all/-a: all.",
   "cli.help.build_desc": "Decompile and index (overwrites code and DB). Default: release; --all/-a: all.",
   "cli.help.index_desc": "Indexes the code into the SQLite database (FTS5). Default: release; --all/-a: all.",

--- a/src/prism/locales/es.json
+++ b/src/prism/locales/es.json
@@ -14,6 +14,7 @@
   "cli.help.arguments_panel": "Argumentos",
   "cli.help.commands_panel": "Comandos",
   "cli.help.options_panel": "Opciones",
+  "cli.help.version": "Muestra la versión y sale.",
   "cli.help.decompile_desc": "Descompila el JAR y deja solo com.hypixel.hytale. Por defecto: release; --all/-a: todas.",
   "cli.help.build_desc": "Descompila e indexa (sobrescribe código y DB). Por defecto: release; --all/-a: todas.",
   "cli.help.index_desc": "Indexa el código en SQLite (FTS5). Por defecto: release; --all/-a: todas.",


### PR DESCRIPTION
## Summary
Implemented global flags \`--version\` and \`-v\` for the CLI, allowing users to quickly verify the current version of Orbis Prism.

## Changes
- **CLI Flags**: Added \`--version\` and \`-v\` flags using Typer's eager callbacks.
- **Dynamic Versioning**: Updated branding logic to pull the version directly from \`prism.__version__\` instead of a hardcoded string.
- **Internationalization**: Added translated help strings for the version flag in both English (\`en.json\`) and Spanish (\`es.json\`).

## Implementation Details
- Modified \`src/prism/entrypoints/cli/main.py\` to include the \`version_callback\` and register the option in \`main_callback\`.
- Updated \`src/prism/entrypoints/cli/branding.py\` to import and use \`__version__\`.
